### PR TITLE
Build arm64 image + automate with GitHub Actions

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,30 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: user/app:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL org.opencontainers.image.authors="alturismo@gmail.com"
 # Set Variables
 ARG MICROSOCKS_V=1.0.4
 ARG HIDEME_V=0.9.9
+ARG TARGETARCH
 
 # Add compile dependencies for Microsocks
 RUN apk update && \
@@ -18,7 +19,7 @@ RUN wget -O /tmp/microsocks_v${MICROSOCKS_V}.tar.gz https://github.com/rofl0r/mi
     DESTDIR=/tmp/copy make install
 
 # Download hide.me binary and move binary to copy directory
-RUN wget -O /tmp/hide.me_v${HIDEME_V}.tar.gz https://github.com/eventure/hide.client.linux/releases/download/${HIDEME_V}/hide.me-linux-amd64-${HIDEME_V}.tar.gz && \
+RUN wget -O /tmp/hide.me_v${HIDEME_V}.tar.gz https://github.com/eventure/hide.client.linux/releases/download/${HIDEME_V}/hide.me-linux-$TARGETARCH-${HIDEME_V}.tar.gz && \
     tar -C /tmp -xvf /tmp/hide.me_v${HIDEME_V}.tar.gz && \
     mkdir -p /tmp/copy/usr/bin && \
     cp /tmp/hide.me /tmp/copy/usr/bin/hide.me


### PR DESCRIPTION
Hey man, thanks for the image! I noticed you only published a amd64 build, but arm64 builds/works just fine, so I set up a GitHub Action to make it easier on you in the future. You'll just need to set up a `DOCKERHUB_USERNAME` var and `DOCKERHUB_TOKEN` secret for the repo and then both platforms should be built + published on every commit.

YAML is just taken from [Docker's docs](https://docs.docker.com/build/ci/github-actions/multi-platform/.)